### PR TITLE
make it work with versions prior to 0.60 stable

### DIFF
--- a/lib/spree_print_invoice.rb
+++ b/lib/spree_print_invoice.rb
@@ -8,6 +8,11 @@ module PrintInvoice
     def self.activate
 
       Admin::OrdersController.class_eval do
+        if Spree.version < '0.60'
+          respond_to :html
+          alias_method :load_order, :load_object
+        end
+        
         def show
           load_order
           respond_with(@order) do |format|


### PR DESCRIPTION
(the load_order method was called load_object before)
