### PR TITLE
Add respond_to to controller so it doesn't throw 406

### DIFF
--- a/app/controllers/spree/admin/orders_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders_controller_decorator.rb
@@ -1,4 +1,6 @@
 Spree::Admin::OrdersController.class_eval do
+  respond_to :pdf
+
   def show
     load_order
     respond_with(@order) do |format|


### PR DESCRIPTION
Fixes #9

When the PDF file gets requested, the Accept header specifies PDF, but the
controller didn't have that as a response type, so it would throw a 406 not
acceptable to the client.  This patch registers PDF as a response type for
the controller.
