### PR TITLE
Update invoice to include options from spree_flexi_variants

### DIFF
--- a/app/views/spree/admin/orders/_line_items_box.pdf.prawn
+++ b/app/views/spree/admin/orders/_line_items_box.pdf.prawn
@@ -32,7 +32,7 @@ bounding_box [0,cursor], :width => 540, :height => 430 do
     content = []
     @order.line_items.each do |item|
       row = [ item.variant.product.sku, item.variant.product.name]
-      row << variant_options(item.variant)
+      row << item.variant.option_values.map {|ov| "#{ov.option_type.presentation}: #{ov.presentation}"}.concat(item.respond_to?('ad_hoc_option_values') ? item.ad_hoc_option_values.map {|pov| "#{pov.option_value.option_type.presentation}: #{pov.option_value.presentation}"} : []).join(', ')
       row << number_to_currency(item.price) unless @hide_prices
       row << item.quantity
       row << number_to_currency(item.price * item.quantity) unless @hide_prices


### PR DESCRIPTION
The spree_flexi_variants extension makes new ad_hoc option types
which aren't in the variant.  This patch allows the invoice to show
all of the options, including the ad_hoc ones.
