### PR TITLE
Update escape character

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,16 +1,9 @@
 # Sample localization file for English. Add more files in this directory for other locales.
 
 en:
-  customer_invoice: Customer Invoice
-  footer_left: "Return in\n Other info"
-  footer_left2: " 14 days \n or never"
-
-  footer_right: "Company  \Phone  \n www "
-  footer_right2: " My great company \n040 146 1222 \n  www.gohereoften.com"
-  
-  print_note: This is not an original invoice (DO NOT SEND THIS TO CUSTOMER)
-  
-  invoice_print: Print Invoice
-  packaging_slip_print: Print Slip
-  packaging_slip: Packaging Slip
+  customer_invoice: "Customer Invoice"
+  print_note: "This is not an original invoice (DO NOT SEND THIS TO CUSTOMER)"
+  invoice_print: "Print Invoice"
+  packaging_slip_print: "Print Slip"
+  packaging_slip: "Packaging Slip"
   


### PR DESCRIPTION
The gem was breaking the Spree application because it was trying to escape \O rather than \n
