### PR TITLE
Check for pre-existing pdf mime type (fixes #24).

### DIFF
--- a/lib/spree_print_invoice/engine.rb
+++ b/lib/spree_print_invoice/engine.rb
@@ -7,7 +7,7 @@ module SpreePrintInvoice
     end
     
     initializer "spree.print_invoice.mimetypes" do |app|
-      Mime::Type.register 'application/pdf', :pdf
+      Mime::Type.register('application/pdf', :pdf) unless Mime::Type.lookup_by_extension(:pdf)
     end
     
     def self.activate


### PR DESCRIPTION
Stops this warning from showing up when the pdf mime type has already been defined:
`warning: already initialized constant PDF`
