### PR TITLE
Only show eligible adjustments

### DIFF
--- a/app/views/spree/admin/orders/_totals.pdf.prawn
+++ b/app/views/spree/admin/orders/_totals.pdf.prawn
@@ -2,7 +2,7 @@ totals = []
 
 totals << [Prawn::Table::Cell.new( :text => Spree.t(:subtotal), :font_style => :bold), @order.display_item_total.to_s]
 
-@order.adjustments.select {|a| a.eligible? }.each do |charge|
+@order.adjustments.eligible.each do |charge|
   totals << [Prawn::Table::Cell.new( :text => charge.label + ":", :font_style => :bold), charge.display_amount.to_s]
 end
 


### PR DESCRIPTION
Filter out any non eligible adjustments.

Fix for https://github.com/spree/spree_print_invoice/issues/41
