### PR TITLE
Basic PDF rendering options

### DIFF
--- a/app/helpers/spree/admin/print_invoice_helper.rb
+++ b/app/helpers/spree/admin/print_invoice_helper.rb
@@ -1,0 +1,14 @@
+module Spree
+  module Admin
+    module PrintInvoiceHelper
+      def font_faces
+        fonts = Prawn::Font::AFM::BUILT_INS.reject { |f| f =~ /zapf|symbol|bold|italic|oblique/i }.map { |f| [f.tr('-', ' '), f] }
+        options_for_select(fonts, Spree::PrintInvoice::Config[:print_invoice_font_face])
+      end
+
+      def logo_scale
+        Spree::PrintInvoice::Config[:print_invoice_logo_scale].to_f / 100
+      end
+    end
+  end
+end

--- a/app/models/spree/print_invoice_configuration.rb
+++ b/app/models/spree/print_invoice_configuration.rb
@@ -3,6 +3,8 @@ module Spree
 
     preference :print_invoice_next_number, :integer, :default => nil
     preference :print_invoice_logo_path, :string, :default => Spree::Config[:admin_interface_logo]
+    preference :print_invoice_logo_scale, :integer, :default => 50
+    preference :print_invoice_font_face, :string, :default => 'Helvetica'
     preference :print_buttons, :string, :default => 'invoice'
     preference :prawn_options, :hash, :default => {}
 

--- a/app/views/spree/admin/general_settings/_invoice.html.erb
+++ b/app/views/spree/admin/general_settings/_invoice.html.erb
@@ -2,8 +2,18 @@
   <legend align="center"><%= Spree.t(:invoices_settings)%></legend>
 
   <div class="field">
+    <%= label_tag :invoice_font_face, Spree.t(:invoice_font_face) %><br>
+    <%= select_tag :print_invoice_font_face, font_faces, :class => 'fullwidth select2' %>
+  </div>
+
+  <div class="field">
     <%= label_tag :print_invoice_next_number, Spree.t(:next_invoice_number) %><br>
     <%= number_field_tag :print_invoice_next_number, Spree::PrintInvoice::Config[:print_invoice_next_number], :size => 8 %>
+  </div>
+
+  <div class="field">
+    <%= label_tag :print_invoice_logo_scale, Spree.t(:invoice_logo_scale) %><br>
+    <%= number_field_tag :print_invoice_logo_scale, Spree::PrintInvoice::Config[:print_invoice_logo_scale], :in => 1...100 %>
   </div>
 
 </fieldset>

--- a/app/views/spree/admin/orders/_address.pdf.prawn
+++ b/app/views/spree/admin/orders/_address.pdf.prawn
@@ -25,7 +25,7 @@ data = [
 ]
 
 move_down 75
-table(data, :width => 525) do
+table(data, :width => 540) do
   row(0).font_style = :bold
 
   # Billing address header

--- a/app/views/spree/admin/orders/_line_items_box.pdf.prawn
+++ b/app/views/spree/admin/orders/_line_items_box.pdf.prawn
@@ -40,7 +40,7 @@ unless @hide_prices
 end
 
 move_down(250)
-table(data, :width => 525) do
+table(data, :width => 540) do
   cells.border_width = 0.5
 
   row(0).borders = [:bottom]

--- a/app/views/spree/admin/orders/_print.pdf.prawn
+++ b/app/views/spree/admin/orders/_print.pdf.prawn
@@ -1,9 +1,11 @@
 require 'prawn/layout'
 
-font "Helvetica"
+@font_face = Spree::PrintInvoice::Config[:print_invoice_font_face]
+
+font @font_face
 
 im = Rails.application.assets.find_asset(Spree::PrintInvoice::Config[:print_invoice_logo_path])
-image im , :at => [0,720] #, :scale => 0.35
+image im , :at => [0,720], :scale => logo_scale
 
 fill_color "E99323"
 if @hide_prices
@@ -17,21 +19,21 @@ move_down 4
 
 if Spree::PrintInvoice::Config.use_sequential_number? && @order.invoice_number.present? && !@hide_prices
 
-  font "Helvetica",  :size => 9,  :style => :bold
+  font @font_face,  :size => 9,  :style => :bold
   text "#{Spree.t(:invoice_number)} #{@order.invoice_number}", :align => :right
 
   move_down 2
-  font "Helvetica", :size => 9
+  font @font_face, :size => 9
   text "#{Spree.t(:invoice_date)} #{I18n.l @order.invoice_date}", :align => :right
 
 else
 
   move_down 2
-  font "Helvetica",  :size => 9
+  font @font_face,  :size => 9
   text "#{Spree.t(:order_number, :number => @order.number)}", :align => :right
 
   move_down 2
-  font "Helvetica", :size => 9
+  font @font_face, :size => 9
   text "#{I18n.l @order.completed_at.to_date}", :align => :right
 
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,5 +15,8 @@ en:
     packaging_slip_print: Print Slip
     packaging_slip: Packaging Slip
 
+    invoice_font_face: Invoice Font Face
+    invoice_logo_scale: Invoice Logo Scale
+
     invoice_number: Invoice Number
     invoice_date: Invoice issued on


### PR DESCRIPTION
This adds two settings to Configuration > General Settings > Invoice Settings in the Spree backend. The first  allows the default font face to be set and the second provides an option for scaling the logo image down. This can currently be achieved by overriding the templates, but it's useful to allow some basic adjustments to be made from within the admin panel.

I also made the width of the address and line items boxes bump up the the right-hand margin of the PDF. There was roughly a 1/4 inch gap causing the border to not line up with the right justified text.
