### PR TITLE
2-0-stable branch has a dependency on 'spree_core (~> 2.1.0)'

### DIFF
--- a/spree-print-invoice.gemspec
+++ b/spree-print-invoice.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.authors      = 'Spree Community'
 
   s.add_dependency('prawn', '1.0.0')
-  s.add_dependency('spree_core', '~> 2.1.0')
+  s.add_dependency('spree_core', '~> 2.0.0')
 end


### PR DESCRIPTION
Hi Guys,

A commit 12 days ago changed the 2-0-stable branch's dependency on `spree_core` to ~> 2.1.0

I think this need to be fixed?

https://github.com/spree/spree_print_invoice/commit/fce9789525b2e7d34773fc809874bb73cf4303f5#diff-26c1a21d5645e61fa28b4eb1ffef373dR17

Thanks,

David
