### PR TITLE
added config option for prawn (allows setting page size, margins)

### DIFF
--- a/app/models/spree/print_invoice_configuration.rb
+++ b/app/models/spree/print_invoice_configuration.rb
@@ -4,6 +4,7 @@ module Spree
     preference :print_invoice_next_number, :integer, :default => nil
     preference :print_invoice_logo_path, :string, :default => Spree::Config[:admin_interface_logo]
     preference :print_buttons, :string, :default => 'invoice'
+    preference :prawn_options, :hash, :default => {}
 
     def use_sequential_number?
       print_invoice_next_number.present? && print_invoice_next_number > 0

--- a/lib/prawn_handler.rb
+++ b/lib/prawn_handler.rb
@@ -13,7 +13,7 @@ module ActionView
       
       module DocumentProxy
         def pdf
-          @pdf ||= ::Prawn::Document.new
+          @pdf ||= ::Prawn::Document.new(Spree::PrintInvoice::Config[:prawn_options])
         end
         
       private


### PR DESCRIPTION
to use just add 
`Spree::PrintInvoice::Config.set prawn_options: { page_layout: :landscape, page_size: "A4" }` in an initializer
