### PR TITLE
Updating print buttons to use font awesome 4.0

### DIFF
--- a/app/views/spree/admin/orders/_print_buttons.html.erb
+++ b/app/views/spree/admin/orders/_print_buttons.html.erb
@@ -2,6 +2,6 @@
   <% buttons = Spree::PrintInvoice::Config[:print_buttons]
      buttons = buttons.split(",").collect{|b| b.strip } %>
   <%  buttons.each do |button| %>
-    <li><%= link_to(Spree.t(button.to_s + "_print"), spree.admin_order_path(@order, :pdf , :template => button), :class => "button icon-print") %></li>
+    <li><%= link_to(Spree.t(button.to_s + "_print"), spree.admin_order_path(@order, :pdf , :template => button), :class => "button fa fa-print") %></li>
   <% end %>
 <% end %>  


### PR DESCRIPTION
This is broken under 2-2-stable after @radar's sweet Font Awesome upgrade.  This _should_ sort it out.
