### PR TITLE
Reattached @column_widths in line_items_print_box template.

### DIFF
--- a/app/views/spree/admin/orders/_line_items_box.pdf.prawn
+++ b/app/views/spree/admin/orders/_line_items_box.pdf.prawn
@@ -40,7 +40,7 @@ unless @hide_prices
 end
 
 move_down(250)
-table(data, :width => 540, :column_widths => @column_widths) do
+table(data, :width => @column_widths.values.compact.sum, :column_widths => @column_widths) do
   cells.border_width = 0.5
 
   row(0).borders = [:bottom]


### PR DESCRIPTION
Previously that `@column_widths` ivar was going nowhere (2-2-stable).  Passing it to the `table()` block ensures that the output dimensions match the widths as set above.
