### PR TITLE
Bump Spree dependency to 2.4.x

### DIFF
--- a/spree-print-invoice.gemspec
+++ b/spree-print-invoice.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.authors      = 'Spree Community'
 
   s.add_dependency('prawn', '1.0.0')
-  s.add_dependency('spree_core', '~> 2.3.0.beta')
+  s.add_dependency('spree_core', '~> 2.4.0')
 
   s.add_development_dependency 'rspec-rails', '~> 2.14.0'
 end


### PR DESCRIPTION
Merge this into a new 2-4-stable branch.
