### PR TITLE
[Spree 3.0.0] payment.number should be used instead of payment.identifier

### DIFF
--- a/app/views/spree/admin/orders/invoice.pdf.prawn
+++ b/app/views/spree/admin/orders/invoice.pdf.prawn
@@ -110,7 +110,7 @@ grid([1,0], [6,4]).bounding_box do
       make_cell(
         content: Spree.t(:payment_via,
         gateway: (payment.source_type || Spree.t(:unprocessed, scope: :print_invoice)),
-        number: payment.identifier,
+        number: payment.number,
         date: I18n.l(payment.updated_at.to_date, format: :long),
         scope: :print_invoice)
       ),


### PR DESCRIPTION
See details here: https://github.com/spree/spree/commit/5ed195e823a7e3ddd02e61c155c6caa0c2147431
