### PR TITLE
Fixes printing of PDFs with missing logo. Refs #75

### DIFF
--- a/app/views/spree/admin/orders/invoice.pdf.prawn
+++ b/app/views/spree/admin/orders/invoice.pdf.prawn
@@ -6,7 +6,7 @@ define_grid(columns: 5, rows: 8, gutter: 10)
 # HEADER
 repeat(:all) do
   im = Rails.application.assets.find_asset(Spree::PrintInvoice::Config[:logo_path])
-  if File.exist? im
+  if File.exist? im.pathname
     image im, vposition: :top, height: 40, scale: Spree::PrintInvoice::Config[:logo_scale]
   end
 

--- a/app/views/spree/admin/orders/packaging_slip.pdf.prawn
+++ b/app/views/spree/admin/orders/packaging_slip.pdf.prawn
@@ -6,7 +6,7 @@ define_grid(columns: 5, rows: 8, gutter: 10)
 # HEADER
 repeat(:all) do
   im = Rails.application.assets.find_asset(Spree::PrintInvoice::Config[:logo_path])
-  if File.exist? im
+  if File.exist? im.pathname
     image im, vposition: :top, height: 40, scale: Spree::PrintInvoice::Config[:logo_scale]
   end
 


### PR DESCRIPTION
Since Rails asset finder returns `nil` if the logo cannot be found, but `File.exist?` takes a `String` we get a `TypeError: no implicit conversion of nil into String` for missing logos. This fixes this.