### PR TITLE
Only include spree controller requests test helper in controller specs.

### DIFF
--- a/spec/support/spree.rb
+++ b/spec/support/spree.rb
@@ -6,7 +6,7 @@ require 'spree/testing_support/url_helpers'
 require 'spree/testing_support/capybara_ext'
 
 RSpec.configure do |config|
-  config.include Spree::TestingSupport::ControllerRequests
+  config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.include Spree::TestingSupport::Preferences
   config.include Spree::TestingSupport::UrlHelpers
 end


### PR DESCRIPTION
The test suite [is currently broken](https://travis-ci.org/spree-contrib/spree_print_invoice/jobs/54901249#L287)