### PR TITLE
Set invoice attributes on state change to "completed"

### DIFF
--- a/app/controllers/spree/admin/orders_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders_controller_decorator.rb
@@ -8,8 +8,6 @@ module Spree
 
         respond_with(@order) do |format|
           format.pdf do
-            @order.update_invoice_number!
-
             send_data @order.pdf_file(pdf_template_name),
               type: 'application/pdf', disposition: 'inline'
           end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,20 +1,24 @@
 Spree::Order.class_eval do
+  # Update the invoice number before transitioning to complete
+  #
+  state_machine.before_transition to: :complete, do: :update_invoice_number!
 
   # Updates +invoice_number+ without calling ActiveRecord callbacks
   #
   # Only updates if number is not already present and if
   # +Spree::PrintInvoice::Config.next_number+ is set and greater than zero.
   #
-  # Also sets +invoice_date+ to current date.
-  #
   def update_invoice_number!
     return unless Spree::PrintInvoice::Config.use_sequential_number?
     return if invoice_number.present?
 
-    update_columns(
-      invoice_number: Spree::PrintInvoice::Config.increase_invoice_number,
-      invoice_date: Date.today
-    )
+    update_columns(invoice_number: Spree::PrintInvoice::Config.increase_invoice_number)
+  end
+
+  # Returns the invoice date
+  #
+  def invoice_date
+    completed_at
   end
 
   # Returns the given template as pdf binary suitable for Rails send_data

--- a/db/migrate/20150608145856_remove_invoice_date_column.rb
+++ b/db/migrate/20150608145856_remove_invoice_date_column.rb
@@ -1,0 +1,5 @@
+class RemoveInvoiceDateColumn < ActiveRecord::Migration
+  def change
+    remove_column :spree_orders, :invoice_date, :date
+  end
+end

--- a/spec/controllers/spree/admin/orders_controller_decorator_spec.rb
+++ b/spec/controllers/spree/admin/orders_controller_decorator_spec.rb
@@ -14,18 +14,6 @@ RSpec.describe Spree::Admin::OrdersController, type: :controller do
       expect(response).to be_success
     end
 
-    context 'with next_number set' do
-      before do
-        allow(Spree::PrintInvoice::Config).to receive(:next_number).and_return(100)
-      end
-
-      it 'sets the invoice number' do
-        expect {
-          spree_get :show, id: order.number, format: :pdf
-        }.to change(order, :invoice_number)
-      end
-    end
-
     context 'with wrong template name' do
       it 'raises error' do
         expect {

--- a/spec/features/spree/admin/print_invoice_spec.rb
+++ b/spec/features/spree/admin/print_invoice_spec.rb
@@ -1,7 +1,7 @@
 RSpec.feature 'Admin print invoice feature' do
   stub_authorization!
 
-  let!(:order) { create(:order_ready_to_ship) }
+  let!(:order) { create(:order_ready_to_ship, invoice_number: 100) }
 
   scenario 'shows print buttons on the order detail page.' do
     visit spree.edit_admin_order_path(id: order.number)

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -9,12 +9,6 @@ RSpec.describe Spree::Order do
       }.to change(order, :invoice_number)
     end
 
-    it 'updates invoice date' do
-      expect {
-        order.update_invoice_number!
-      }.to change(order, :invoice_date)
-    end
-
     context 'with invoice number present' do
       before do
         order.invoice_number = "1000"
@@ -24,12 +18,6 @@ RSpec.describe Spree::Order do
         expect {
           order.update_invoice_number!
         }.to_not change(order, :invoice_number)
-      end
-
-      it 'does not update invoice date' do
-        expect {
-          order.update_invoice_number!
-        }.to_not change(order, :invoice_date)
       end
     end
 
@@ -45,12 +33,31 @@ RSpec.describe Spree::Order do
           order.update_invoice_number!
         }.to_not change(order, :invoice_number)
       end
+    end
+  end
 
-      it 'does not update invoice date' do
-        expect {
-          order.update_invoice_number!
-        }.to_not change(order, :invoice_date)
-      end
+  describe "checkout flow" do
+    let(:order) { create :order_with_line_items, state: "confirm" }
+
+    before do
+      allow(order).to receive(:ensure_line_item_variants_are_not_deleted) { true }
+      allow(order).to receive(:ensure_line_items_are_in_stock) { true }
+      order.payments = [create(:payment)]
+    end
+
+    it "updates the invoice number when completing the order" do
+      expect do
+        order.next
+      end.to change(order, :invoice_number)
+    end
+  end
+
+  describe "invoice_date" do
+    let(:order) { Spree::Order.new }
+
+    it "calls completed at" do
+      expect(order).to receive(:completed_at)
+      order.invoice_date
     end
   end
 end


### PR DESCRIPTION
Before, `invoice_number` and `invoice_date` were both independent
columns that would be set whenever the invoice would be printed.

However, there should be an invoice for every order, so this commit
changes that behaviour to set the invoice number when the order changes
to complete.

With this change, invoice_date becomes obsolete. I added a delegator
method to use completed_at instead (which is set more or less at the
same time).

Over here, the tax authorities require that invoice numbers be chronological (i.e. they have to have the same sequence as the respective invoice dates). If the invoice_number only gets made when the PDF is produced (e.g. in a Sidekiq job), they could get out of sync, and that would (again, Germany talking here) be not so good.

Note that this PR also de-couples the PDF rendering from the number generation. There is no PDF being rendered upon changing the order state to complete, just the number is generated for future use in rendering.