### PR TITLE
Add Bookkeeping Document ID to cached PDF file name

### DIFF
--- a/app/models/spree/bookkeeping_document.rb
+++ b/app/models/spree/bookkeeping_document.rb
@@ -70,7 +70,7 @@ module Spree
     # = The PDF file_name
     #
     def file_name
-      @_file_name ||= "#{template}-#{printable.number}.pdf"
+      @_file_name ||= "#{template}-D#{id}-N#{number}.pdf"
     end
 
     # = PDF file path

--- a/spec/features/spree/admin/print_invoice_spec.rb
+++ b/spec/features/spree/admin/print_invoice_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature 'Admin print invoice feature' do
         visit spree.admin_bookkeeping_document_path(id: order.invoice.id, format: :pdf)
         expect(page.body).to eq(
           IO.binread(
-            Rails.root.join('..', '..', 'spec', 'dummy', 'tmp', 'order_prints', 'invoices', "invoice-#{order.number}.pdf")
+            Rails.root.join('..', '..', 'spec', 'dummy', 'tmp', 'order_prints', 'invoices', "invoice-D#{order.invoice.id}-N#{order.invoice.number}.pdf")
           )
         )
       end


### PR DESCRIPTION
In case your app is (admittedly) wrongly configured so that invoice numbers
for some reason not unique, you might end sending the wrong invoice to
your customer. This commit mitigates that by including the document ID
in the filename.