### PR TITLE
Add dependent: :destroy to the document associations

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,5 +1,5 @@
 Spree::Order.class_eval do
-  has_many :bookkeeping_documents, as: :printable
+  has_many :bookkeeping_documents, as: :printable, dependent: :destroy
   has_one :invoice, -> { where(template: 'invoice') },
           class_name: 'Spree::BookkeepingDocument',
           as: :printable

--- a/spec/controllers/spree/admin/bookkeeping_documents_controller_spec.rb
+++ b/spec/controllers/spree/admin/bookkeeping_documents_controller_spec.rb
@@ -1,6 +1,12 @@
 RSpec.describe Spree::Admin::BookkeepingDocumentsController, type: :controller do
   stub_authorization!
 
+  before do
+    reset_spree_preferences
+    user = build(:admin_user)
+    allow(controller).to receive(:try_spree_current_user).and_return(user)
+  end
+
   describe '#show as :pdf' do
     context 'an order invoice' do
       let!(:order) { create(:invoiceable_order) }

--- a/spec/controllers/spree/admin/print_invoice_settings_controller_spec.rb
+++ b/spec/controllers/spree/admin/print_invoice_settings_controller_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Spree::Admin::PrintInvoiceSettingsController, type: :controller d
 
   before do
     reset_spree_preferences
-    user = create(:admin_user)
+    user = build(:admin_user)
     allow(controller).to receive(:try_spree_current_user).and_return(user)
   end
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -89,5 +89,17 @@ RSpec.describe Spree::Order do
         end
       end
     end
+
+    describe 'destruction' do
+      let!(:order) { create :invoiceable_order }
+
+      context "when destroyed" do
+        it 'also destroys the invoice' do
+          expect(Spree::BookkeepingDocument.count).not_to eq(0)
+          order.destroy!
+          expect(Spree::BookkeepingDocument.count).to eq(0)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
When you delete a `Spree::Order`, you'll end up with invalid documents (the
document won't be able to infer its view class or fetch any of its contents).

That happened here, and it'd be much nicer if the document just went away when the
order in question is destroyed, too.

Of course: Do not destroy completed orders if you don't exactly know what you're doing!