### PR TITLE
Make the invoice number formattable

### DIFF
--- a/app/models/spree/printables/invoice/base_view.rb
+++ b/app/models/spree/printables/invoice/base_view.rb
@@ -54,7 +54,7 @@ module Spree
 
     def number
       if use_sequential_number?
-        Spree::PrintInvoice::Config.next_number
+        formatted_number
       else
         printable.number
       end
@@ -65,6 +65,18 @@ module Spree
     end
 
     private
+
+    def formatted_number
+      if (Object.const_get('::Spree::PrintInvoice::NumberFormatter') rescue false)
+        ::Spree::PrintInvoice::NumberFormatter.new(next_number).to_s
+      else
+        next_number
+      end
+    end
+
+    def next_number
+      Spree::PrintInvoice::Config.next_number
+    end
 
     def increase_invoice_number!
       Spree::PrintInvoice::Config.increase_invoice_number!

--- a/spec/models/spree/printables/invoice/base_view_spec.rb
+++ b/spec/models/spree/printables/invoice/base_view_spec.rb
@@ -68,14 +68,17 @@ RSpec.describe Spree::Printables::Invoice::BaseView do
   end
 
   describe '#number' do
+    before do
+      allow(Spree::PrintInvoice::Config).to receive(:next_number) { 77 }
+    end
+
     context 'when using sequential numbers' do
       before do
         allow(Spree::PrintInvoice::Config).to receive(:use_sequential_number?) { true }
       end
 
-      it 'calls next_number on Spree::PrintInvoice::Config' do
-        expect(Spree::PrintInvoice::Config).to receive(:next_number)
-        base_view.number
+      it 'returns the next number without additional formatting' do
+        expect(base_view.number).to eq(77)
       end
     end
 
@@ -87,6 +90,24 @@ RSpec.describe Spree::Printables::Invoice::BaseView do
       it 'calls the printables number' do
         expect(printable).to receive(:number)
         base_view.number
+      end
+    end
+
+    context 'when using a NumberFormatter' do
+      before do
+        class Spree::PrintInvoice::NumberFormatter
+          def initialize(number)
+            @number = number
+          end
+
+          def to_s
+            "MY-NICE-INVOICE-#{@number}"
+          end
+        end
+      end
+
+      it 'returns a nicely formatted number' do
+        expect(base_view.number).to eq("MY-NICE-INVOICE-77")
       end
     end
   end


### PR DESCRIPTION
In order to satisfy jurisdictions where invoice numbers
have to conform specific formal requirements (number of digits, prefix, whatever)
you can now define a `Spree::PrintInvoice::NumberFormattter` class
which initializes with a integer, and implements a `to_s` method returning a
formatted number.