### PR TITLE
Fix Sprockets 3

### DIFF
--- a/app/views/spree/admin/orders/_print.pdf.prawn
+++ b/app/views/spree/admin/orders/_print.pdf.prawn
@@ -5,7 +5,8 @@ require 'prawn/layout'
 font @font_face
 
 im = Rails.application.assets.find_asset(Spree::PrintInvoice::Config[:print_invoice_logo_path])
-image im.pathname, :at => [0,720], :scale => logo_scale
+logo_path = Sprockets::VERSION.start_with? '2' ? im : im.pathname
+image logo_path, :at => [0,720], :scale => logo_scale
 
 fill_color "E99323"
 if @hide_prices

--- a/app/views/spree/admin/orders/_print.pdf.prawn
+++ b/app/views/spree/admin/orders/_print.pdf.prawn
@@ -5,7 +5,7 @@ require 'prawn/layout'
 font @font_face
 
 im = Rails.application.assets.find_asset(Spree::PrintInvoice::Config[:print_invoice_logo_path])
-image im , :at => [0,720], :scale => logo_scale
+image im.pathname, :at => [0,720], :scale => logo_scale
 
 fill_color "E99323"
 if @hide_prices


### PR DESCRIPTION
Updating sprockets to 3.5 caused us to come across this issue:

```
ActionView::Template::Error (no implicit conversion of Sprockets::Asset into String):
     5: font @font_face
     6:
     7: im = Rails.application.assets.find_asset(Spree::PrintInvoice::Config[:print_invoice_logo_path])
     8: image im , :at => [0,720], :scale => logo_scale
```
