### PR TITLE
use filename of the image

### DIFF
--- a/app/views/spree/admin/orders/packaging_slip.pdf.prawn
+++ b/app/views/spree/admin/orders/packaging_slip.pdf.prawn
@@ -7,7 +7,7 @@ define_grid(columns: 5, rows: 8, gutter: 10)
 repeat(:all) do
   im = Rails.application.assets.find_asset(Spree::PrintInvoice::Config[:logo_path])
   if im && File.exist?(im.pathname)
-    image im, vposition: :top, height: 40, scale: Spree::PrintInvoice::Config[:logo_scale]
+    image im.filename, vposition: :top, height: 40, scale: Spree::PrintInvoice::Config[:logo_scale]
   end
 
   grid([0,3], [0,4]).bounding_box do


### PR DESCRIPTION
avoid no implicit conversion of Sprockets::Asset into String