### PR TITLE
Lock pg to ~> 0.18

### DIFF
--- a/spree-print-invoice.gemspec
+++ b/spree-print-invoice.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'guard-rspec'
   s.add_development_dependency 'pry-rails'
   s.add_development_dependency 'rubocop'
-  s.add_development_dependency 'pg'
+  s.add_development_dependency 'pg', '~> 0.18'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'appraisal'
 end


### PR DESCRIPTION
1.0.0 doesn't work with current Rails version