### PR TITLE
Updated totals partial to show only completed payments

### DIFF
--- a/app/views/spree/printables/shared/_totals.pdf.prawn
+++ b/app/views/spree/printables/shared/_totals.pdf.prawn
@@ -19,7 +19,7 @@ totals << [pdf.make_cell(content: Spree.t(:order_total)), invoice.display_total.
 
 # Payments
 total_payments = 0.0
-invoice.payments.each do |payment|
+invoice.payments.completed.each do |payment|
   totals << [
     pdf.make_cell(
       content: Spree.t(:payment_via,


### PR DESCRIPTION
I agree with the OP on #101 

This commit updates the totals partial so that only completed payments are visible on the resulting invoice.

Please note that tests do not currently pass due to issue I've raised in #123 and resolved in PR #124 