### PR TITLE
Corrected style classes for spree >= 4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'coffee-rails'
 gem 'spree', github: 'spree/spree'
 gem 'spree_auth_devise', github: 'spree/spree_auth_devise'
 gem 'rails-controller-testing'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'coffee-rails'
 gem 'spree', github: 'spree/spree'
 gem 'spree_auth_devise', github: 'spree/spree_auth_devise'
 gem 'rails-controller-testing'

--- a/app/assets/javascripts/spree/backend/print_invoice_settings.coffee
+++ b/app/assets/javascripts/spree/backend/print_invoice_settings.coffee
@@ -1,5 +1,0 @@
-$ ->
-  storage_path_field = $('#storage_path')
-
-  $('#store_pdf').click ->
-    storage_path_field.prop('disabled', !$(this).prop('checked'))

--- a/app/assets/javascripts/spree/backend/print_invoice_settings.js
+++ b/app/assets/javascripts/spree/backend/print_invoice_settings.js
@@ -1,0 +1,7 @@
+$(function() {
+  var storage_path_field;
+  storage_path_field = $('#storage_path');
+  return $('#store_pdf').click(function() {
+    return storage_path_field.prop('disabled', !$(this).prop('checked'));
+  });
+});

--- a/app/overrides/add_documents_to_main_navigation.rb
+++ b/app/overrides/add_documents_to_main_navigation.rb
@@ -1,6 +1,17 @@
-Deface::Override.new(
-  virtual_path:  'spree/layouts/admin',
-  insert_bottom: '#main-sidebar',
-  partial:       'spree/admin/shared/menu/documents_tab',
-  name:          'documents_tab'
-)
+# frozen_string_literal: true
+
+if Spree.version.to_f < 4.0
+  Deface::Override.new(
+    virtual_path:  'spree/layouts/admin',
+    insert_bottom: '#main-sidebar',
+    partial:       'spree/admin/shared/menu/documents_tab',
+    name:          'documents_tab'
+  )
+else
+  Deface::Override.new(
+    virtual_path:  'spree/admin/shared/_main_menu',
+    insert_bottom: 'nav',
+    partial:       'spree/admin/shared/menu/documents_tab',
+    name:          'documents_tab'
+  )
+end

--- a/app/views/spree/admin/orders/_print_invoice_order_tab_links.html.erb
+++ b/app/views/spree/admin/orders/_print_invoice_order_tab_links.html.erb
@@ -1,11 +1,12 @@
 <% if can? :show, Spree::Order %>
   <% if @order && @order.completed_at? %>
-      <li class='<%= "#{'active' if current == :documents}" %>'>
+      <li data-hook="admin_order_tabs_documents">
         <%=
           link_to_with_icon 'file',
             Spree.t(:documents, scope: :print_invoice),
             spree.admin_order_bookkeeping_documents_path(@order),
-            title: title
+            title: title,
+            class: "#{'active ' if current == :documents}nav-link icon-link with-tip action-refresh"
         %>
       </li>
   <% end %>

--- a/app/views/spree/admin/shared/menu/_documents_tab.html.erb
+++ b/app/views/spree/admin/shared/menu/_documents_tab.html.erb
@@ -1,3 +1,3 @@
-<ul class="nav nav-sidebar">
+<ul class="nav nav-sidebar border-bottom">
   <%= main_menu_tree t(:documents, scope: [:spree, :print_invoice]), url: '#sidebar-documents', icon: 'file', sub_menu: 'documents_sub_menu' %>
 </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,13 @@
 en:
   spree:
     print_invoice:
+      date: Date
+      number: Number
+      firstname: First name
+      lastname: Last name
+      document_type: Document type
+      email: Email
+      total: Total
       documents: Documents
       documents_for_order: "Documents for order %{order_number}"
       buttons:

--- a/spree-print-invoice.gemspec
+++ b/spree-print-invoice.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
+  s.add_runtime_dependency 'coffee-rails'
   s.add_runtime_dependency 'prawn-rails', '~> 0.1.1'
   s.add_runtime_dependency 'spree_core', '>= 3.1.0', '< 5.0'
   s.add_runtime_dependency 'spree_extension'

--- a/spree-print-invoice.gemspec
+++ b/spree-print-invoice.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_runtime_dependency 'coffee-rails'
   s.add_runtime_dependency 'prawn-rails', '~> 0.1.1'
   s.add_runtime_dependency 'spree_core', '>= 3.1.0', '< 5.0'
   s.add_runtime_dependency 'spree_extension'
@@ -34,7 +33,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'database_cleaner'
-  s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'pdf-inspector'
   s.add_development_dependency 'ffaker'


### PR DESCRIPTION
Current gem should have dependency `coffee-rails` because uses CoffeeScript.
Generally new apps do not uses 'coffee' and we had strange errors which should do not have.