### PR TITLE
remove coffee from deps

### DIFF
--- a/app/assets/javascripts/spree/backend/print_invoice_settings.coffee
+++ b/app/assets/javascripts/spree/backend/print_invoice_settings.coffee
@@ -1,5 +1,0 @@
-$ ->
-  storage_path_field = $('#storage_path')
-
-  $('#store_pdf').click ->
-    storage_path_field.prop('disabled', !$(this).prop('checked'))

--- a/app/assets/javascripts/spree/backend/print_invoice_settings.js
+++ b/app/assets/javascripts/spree/backend/print_invoice_settings.js
@@ -1,0 +1,7 @@
+$(function() {
+  var storage_path_field;
+  storage_path_field = $('#storage_path');
+  return $('#store_pdf').click(function() {
+    return storage_path_field.prop('disabled', !$(this).prop('checked'));
+  });
+});

--- a/app/assets/javascripts/spree/frontend/spree_print_invoice.js
+++ b/app/assets/javascripts/spree/frontend/spree_print_invoice.js
@@ -1,1 +1,0 @@
-//= require spree/frontend

--- a/app/assets/stylesheets/spree/backend/spree_print_invoice.css
+++ b/app/assets/stylesheets/spree/backend/spree_print_invoice.css
@@ -1,3 +1,0 @@
-/*
-*= require spree/backend
-*/

--- a/app/assets/stylesheets/spree/frontend/spree_print_invoice.css
+++ b/app/assets/stylesheets/spree/frontend/spree_print_invoice.css
@@ -1,3 +1,0 @@
-/*
-*= require spree/frontend
-*/

--- a/spree-print-invoice.gemspec
+++ b/spree-print-invoice.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'database_cleaner'
-  s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'pdf-inspector'
   s.add_development_dependency 'ffaker'


### PR DESCRIPTION
Appreciate @voleoo fixed the tests! 

This PR is relevant to #138 #139. Let me create smaller PRs for review. 

The coffee file was written in js since Coffee Script was dropped around Spree 4.0. We could remove coffee from dependencies.

