### PR TITLE
Refactoring the migration. 

### DIFF
--- a/app/controllers/spree/admin/bookkeeping_documents_controller.rb
+++ b/app/controllers/spree/admin/bookkeeping_documents_controller.rb
@@ -22,6 +22,14 @@ module Spree
         @bookkeeping_documents = @bookkeeping_documents.page(params[:page] || 1).per(10)
       end
 
+      def refresh
+        unless @order.nil?
+          @order.bookkeeping_documents.delete_all
+          @order.invoice_for_order
+        end
+        redirect_to action: 'index'
+      end
+
       private
 
       def order_focused?

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,49 +1,50 @@
 # frozen_string_literal: true
 
 module Spree
-  module OrderDecorator; end
+  module OrderDecorator
+    def self.prepended(base)
+      base.has_many :bookkeeping_documents, as: :printable, dependent: :destroy
+      base.has_one :invoice, -> { where(template: 'invoice') },
+                   class_name: 'Spree::BookkeepingDocument',
+                   as: :printable
+      base.has_one :packaging_slip, -> { where(template: 'packaging_slip') },
+                   class_name: 'Spree::BookkeepingDocument',
+                   as: :printable
+
+      base.delegate :number, :date, to: :invoice, prefix: true
+
+      # Create a new invoice before transitioning to complete
+      #
+      base.state_machine.before_transition to: :complete, do: :invoice_for_order
+    end
+
+    # Backwards compatibility stuff. Please don't use these methods, rather use the
+    # ones on Spree::BookkeepingDocument
+    #
+    def pdf_file
+      ActiveSupport::Deprecation.warn('This API has changed: Please use order.invoice.pdf instead')
+      invoice.pdf
+    end
+
+    def pdf_filename
+      ActiveSupport::Deprecation.warn('This API has changed: Please use order.invoice.file_name instead')
+      invoice.file_name
+    end
+
+    def pdf_file_path
+      ActiveSupport::Deprecation.warn('This API has changed: Please use order.invoice.pdf_file_path instead')
+      invoice.pdf_file_path
+    end
+
+    def pdf_storage_path(template)
+      ActiveSupport::Deprecation.warn('This API has changed: Please use order.{packaging_slip, invoice}.pdf_file_path instead')
+      bookkeeping_documents.find_by!(template: template).file_path
+    end
+
+    def invoice_for_order
+      bookkeeping_documents.create(template: 'invoice')
+      bookkeeping_documents.create(template: 'packaging_slip')
+    end
+  end
 end
-
-Spree::Order.class_eval do
-  has_many :bookkeeping_documents, as: :printable, dependent: :destroy
-  has_one :invoice, -> { where(template: 'invoice') },
-          class_name: 'Spree::BookkeepingDocument',
-          as: :printable
-  has_one :packaging_slip, -> { where(template: 'packaging_slip') },
-          class_name: 'Spree::BookkeepingDocument',
-          as: :printable
-
-  delegate :number, :date, to: :invoice, prefix: true
-
-  # Create a new invoice before transitioning to complete
-  #
-  state_machine.before_transition to: :complete, do: :invoice_for_order
-
-  # Backwards compatibility stuff. Please don't use these methods, rather use the
-  # ones on Spree::BookkeepingDocument
-  #
-  def pdf_file
-    ActiveSupport::Deprecation.warn('This API has changed: Please use order.invoice.pdf instead')
-    invoice.pdf
-  end
-
-  def pdf_filename
-    ActiveSupport::Deprecation.warn('This API has changed: Please use order.invoice.file_name instead')
-    invoice.file_name
-  end
-
-  def pdf_file_path
-    ActiveSupport::Deprecation.warn('This API has changed: Please use order.invoice.pdf_file_path instead')
-    invoice.pdf_file_path
-  end
-
-  def pdf_storage_path(template)
-    ActiveSupport::Deprecation.warn('This API has changed: Please use order.{packaging_slip, invoice}.pdf_file_path instead')
-    bookkeeping_documents.find_by!(template: template).file_path
-  end
-
-  def invoice_for_order
-    bookkeeping_documents.create(template: 'invoice')
-    bookkeeping_documents.create(template: 'packaging_slip')
-  end
-end
+::Spree::Order.prepend Spree::OrderDecorator

--- a/app/views/spree/admin/bookkeeping_documents/index.html.erb
+++ b/app/views/spree/admin/bookkeeping_documents/index.html.erb
@@ -1,6 +1,10 @@
 <% if order_focused? %>
   <%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :documents } %>
 
+  <% content_for :page_actions do %>
+    <%= button_link_to(Spree.t(@bookkeeping_documents.any? ? :refresh_documents : :create_documents), spree.refresh_admin_order_bookkeeping_documents_path(@order), { class: "btn-primary", icon: @bookkeeping_documents.any? ? 'refresh' :'add', id: 'refresh-bookkeeping' }) %>
+  <% end %>
+
   <% content_for :page_title do %>
     <%= t(:documents_for_order, scope: [:spree, :print_invoice], order_number: @order.number) %>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Spree::Core::Engine.add_routes do
   namespace :admin do
     # https://github.com/spree/spree/blob/3-0-stable/backend/config/routes.rb#L73
     resources :orders do
-      resources :bookkeeping_documents, only: :index
+      resources :bookkeeping_documents, only: :index do
+        get 'refresh', on: :collection
+      end
     end
 
     resource :print_invoice_settings, only: [:edit, :update]

--- a/db/migrate/20150616133616_create_spree_bookkeeping_documents.rb
+++ b/db/migrate/20150616133616_create_spree_bookkeeping_documents.rb
@@ -1,5 +1,5 @@
 class CreateSpreeBookkeepingDocuments < SpreeExtension::Migration[4.2]
-  def up
+  def change
     create_table :spree_bookkeeping_documents do |t|
       t.references :printable, polymorphic: true
       t.string :template
@@ -11,19 +11,5 @@ class CreateSpreeBookkeepingDocuments < SpreeExtension::Migration[4.2]
 
       t.timestamps null: false
     end
-
-    Spree::Order.complete.where.not(invoice_number: nil).find_each do |order|
-      order.pdfs.create(
-        template: 'invoice',
-        number: order.invoice_number,
-        created_at: order.completed_at.to_date
-      )
-    end
-
-    remove_column :spree_orders, :invoice_number, :string
-  end
-
-  def down
-    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/lib/spree_print_invoice/engine.rb
+++ b/lib/spree_print_invoice/engine.rb
@@ -6,16 +6,18 @@ module SpreePrintInvoice
 
     config.autoload_paths += %W(#{config.root}/lib)
 
-    initializer 'spree.print_invoice.environment', before: :load_config_initializers do
+    initializer 'spree.print_invoice.preferences', before: :load_config_initializers do
       Spree::PrintInvoice::Config = Spree::PrintInvoiceSetting.new
     end
 
-    class << self
-      def activate
-        cache_klasses = %W(#{config.root}/app/**/*_decorator*.rb)
-        Dir.glob(cache_klasses) do |klass|
-          Rails.configuration.cache_classes ? require(klass) : load(klass)
-        end
+    # use rspec for tests
+    config.generators do |g|
+      g.test_framework :rspec
+    end
+
+    def self.activate
+      Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')) do |c|
+        Rails.configuration.cache_classes ? require(c) : load(c)
       end
     end
 

--- a/spec/controllers/spree/admin/bookkeeping_documents_controller_spec.rb
+++ b/spec/controllers/spree/admin/bookkeeping_documents_controller_spec.rb
@@ -105,4 +105,13 @@ RSpec.describe Spree::Admin::BookkeepingDocumentsController, type: :controller d
       end
     end
   end
+  describe '#refresh as :html' do
+    let!(:order) { create(:invoiceable_order) }
+
+    it 'create/refresh documents' do
+      get :refresh, params: { order_id: order.number }
+      expect(response).to redirect_to(action: :index)
+      expect(order.bookkeeping_documents).to exist
+    end
+  end
 end


### PR DESCRIPTION
> This PR is relevant to #122 & #139.

Initially, the migration was irreversible. It isn't suitable for people who want to uninstall this extension. Instead of generating all documents during the migration, I borrow the idea from PR #122. Let users generate documents on demand. 

Additionally, since this gem hasn't support file uploading yet, the original way can cause chaos on the production server. I, thus, want to propose to remove the documents generation during the migration. 

> A few tweaks in the order_decorator and engine are included in this PR. 