### PR TITLE
:bug: (bug) fix if config.assets.compile is false on production

### DIFF
--- a/app/views/spree/printables/shared/_header.pdf.prawn
+++ b/app/views/spree/printables/shared/_header.pdf.prawn
@@ -1,4 +1,4 @@
-im = Rails.application.assets.find_asset(Spree::PrintInvoice::Config[:logo_path])
+im = (Rails.application.assets || ::Sprockets::Railtie.build_environment(Rails.application)).find_asset(Spree::PrintInvoice::Config[:logo_path])
 
 if im && File.exist?(im.pathname)
   pdf.image im.filename, vposition: :top, height: 40, scale: Spree::PrintInvoice::Config[:logo_scale]


### PR DESCRIPTION
`Rails.application.assets` is a nil when `config.assets.compile = false`.