### PR TITLE
Allow nil for OrderDecorator delegations to invoice

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -11,7 +11,7 @@ module Spree
                    class_name: 'Spree::BookkeepingDocument',
                    as: :printable
 
-      base.delegate :number, :date, to: :invoice, prefix: true
+      base.delegate :number, :date, to: :invoice, prefix: true, allow_nil: true
 
       # Create a new invoice before transitioning to complete
       #


### PR DESCRIPTION
The serializer gets called for basket purposed and fails on not having an invoice